### PR TITLE
Data Pin Needs to be INPUT_PULLUP

### DIFF
--- a/NESpad.cpp
+++ b/NESpad.cpp
@@ -1,6 +1,6 @@
 /*
   NESpad - Arduino library for interfacing with a NES joystick
-
+  Version: 1.4 (07/09/2015) - Used INPUT_PULLUP to avoid floating ground when controller disconnected
   Version: 1.3 (11/12/2010) - get rid of shortcut constructor - seems to be broken
   Version: 1.2 (05/25/2009) - put pin numbers in constructor (Pascal Hahn)
   Version: 1.1 (09/22/2008) - fixed compilation errors in arduino 0012 (Rob Duarte)
@@ -45,7 +45,7 @@ NESpad::NESpad(int strobe, int clock, int data)
   {
     pinMode(strobe, OUTPUT);
     pinMode(clock,  OUTPUT);
-    pinMode(data, INPUT);
+    pinMode(data, INPUT_PULLUP);
   }
 
 byte NESpad::buttons(void)

--- a/examples/NESpad_serial/NESpad_serial.pde
+++ b/examples/NESpad_serial/NESpad_serial.pde
@@ -10,7 +10,7 @@
 #include <NESpad.h>
 
 // put your own strobe/clock/data pin numbers here -- see the pinout in readme.txt
-SNESpad nintendo = SNESpad(2,3,4);
+NESpad nintendo = NESpad(2,3,4);
 
 byte state = 0;
 


### PR DESCRIPTION
I recently build a Nexus Player into an old NES case and used the original controllers and stock ports on the front. I then converted those ports to a USB Keyboard with an ATMega32u4 Arduino. It worked, but I would get random key-presses when the gamepads were disconnected. After checking some documentation on the NES gamepad protocol I found that the datapins used LOW as TRUE and this made me realize that the data pin was just a floating input when the pad was disconnected, which seems to have an internal pull-up. I added a pull-up to my circuit, but simply adding INPUT_PULLUP to the library fixes it as well.

I also fixed an example which, for some reason, referenced the non-existant SNESPad class.
